### PR TITLE
Update node versions for docker and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: required
 language: node_js
 node_js:
   - 'node'
-  - '8'
 
 services:
   - docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ RUN apt-get update && apt-get install -y \
     curl \
     git \
     sudo
-RUN curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+RUN curl -sL https://deb.nodesource.com/setup_9.x | sudo -E bash -
 RUN apt-get install -y \
     nodejs \
     build-essential


### PR DESCRIPTION
Change Docker to install node 9 instead of 8. Change travis to only build with latest node.