### PR TITLE
Add help to example config

### DIFF
--- a/examples/plugin_configuration.json
+++ b/examples/plugin_configuration.json
@@ -20,6 +20,10 @@
       "configuration": {}
     },
     {
+      "name": "help",
+      "configuration": {}
+    },
+    {
       "name": "feature-request",
       "configuration": {}
     },


### PR DESCRIPTION
Forgot to do this in the last push. Help should be one of the default plugins for sure.